### PR TITLE
Extend to include Places 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ SimpleGeo api endpoints.
             }
         }
     });
+
+For SimpleGeo Places 1.0 and 1.2, you must make separate calls:
+
+    var SimpleGeo = require('simplegeo').SimpleGeo;
+    var sg_places12 = new SimpleGeo.Places12('key', 'secret');
+    sg_places12.getNearbyPlacesText('Stanford University', function(err,data) {
+        for (i in data) {
+            if (data.hasOwnProperty(i)) {
+                console.log(data[i]);
+            }
+        }
+    });

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ SimpleGeo api endpoints.
 For SimpleGeo Places 1.0 and 1.2, you must make separate calls:
 
     var SimpleGeo = require('simplegeo').SimpleGeo;
+    
     var sg_places12 = new SimpleGeo.Places12('key', 'secret');
     sg_places12.getNearbyPlacesText('Stanford University', function(err,data) {
         for (i in data) {

--- a/lib/simplegeo.js
+++ b/lib/simplegeo.js
@@ -100,6 +100,24 @@ var SimpleGeo = exports.SimpleGeo = function(key,secret,customHeaders) {
     }
 }
 
+SimpleGeo.Places = function(token, options) {
+	if (!(this instanceof SimpleGeo.Places)) return new SimpleGeo.Places(token, options);
+	SimpleGeo.call(this, token, options);
+	this.name = 'Places';
+	this.placesVersion = '/1.0';
+}
+
+SimpleGeo.Places.prototype = new SimpleGeo;
+
+SimpleGeo.Places12 = function(token, options) {
+	if (!(this instanceof SimpleGeo.Places12)) return new SimpleGeo.Places12(token, options);
+	SimpleGeo.call(this, token, options);
+	this.name = 'Places12';
+	this.placesVersion = '/1.2';
+}
+
+SimpleGeo.Places.prototype = new SimpleGeo;
+
 
 /////////////////////////////////////////////////////
 /** Storage                                       **/
@@ -355,26 +373,74 @@ SimpleGeo.prototype.getContext = function (type,param,callback) {
 
 
 /////////////////////////////////////////////////////
-/** Places                                        **/
+/** Places 1.0                                    **/
 /////////////////////////////////////////////////////
 
 /**
  * SimpleGeo Places: Search for Nearby Places
  * @see https://simplegeo.com/docs/api-endpoints/simplegeo-places#search
  */
-SimpleGeo.prototype.getNearbyPlacesByLatLng = function (lat, lng, params, callback) {
+SimpleGeo.Places.prototype = new SimpleGeo;
+
+SimpleGeo.Places.prototype.getNearbyPlacesByLatLng = function (lat, lng, params, callback) {
   this.getNearbyPlaces(SimpleGeo.LATLNG, [lat,lng], params, callback)
 }
 
-SimpleGeo.prototype.getNearbyPlacesByAddress = function (address, params, callback) {
+SimpleGeo.Places.prototype.getNearbyPlacesByAddress = function (address, params, callback) {
   this.getNearbyPlaces(SimpleGeo.ADDRESS, address, params, callback)
 }
 
-SimpleGeo.prototype.getNearbyPlacesByIp = function (ip, params, callback) {
+SimpleGeo.Places.prototype.getNearbyPlacesByIp = function (ip, params, callback) {
   this.getNearbyPlaces(SimpleGeo.IP, ip, params, callback)
 }
 
-SimpleGeo.prototype.getNearbyPlaces = function (type,param,params,callback) {
+SimpleGeo.Places.prototype.getNearbyPlaces = function (type,param,params,callback) {
+    var param_string = "";
+    var qs = "";
+
+    if (typeof params == 'function') {
+        callback = params;
+        params = {};
+    }
+
+    switch (type) {
+        case SimpleGeo.LATLNG :
+            param_string = param[0] + "," + param[1];
+        break;
+        case SimpleGeo.ADDRESS : 
+            param_string = 'address';
+            params['address'] = param;
+        break;
+        case SimpleGeo.IP :
+            param_string = param;
+        break;
+    }
+
+    qs = QueryString.stringify(params);
+    this.secure_call('1.0','/places/'+param_string+'.json?'+qs,'GET',callback);
+}
+
+/////////////////////////////////////////////////////
+/** Places 1.2                                    **/
+/////////////////////////////////////////////////////
+
+/**
+ * SimpleGeo Places: Search for Nearby Places
+ * @see https://simplegeo.com/docs/api-endpoints/simplegeo-places#search
+ */
+SimpleGeo.Places12.prototype.getNearbyPlacesByLatLng = function (lat, lng, params, callback) {
+  this.getNearbyPlaces(SimpleGeo.LATLNG, [lat,lng], params, callback)
+}
+
+SimpleGeo.Places12.prototype.getNearbyPlacesByAddress = function (address, params, callback) {
+  this.getNearbyPlaces(SimpleGeo.ADDRESS, address, params, callback)
+}
+
+SimpleGeo.Places12.prototype.getNearbyPlacesByIp = function (ip, params, callback) {
+  this.getNearbyPlaces(SimpleGeo.IP, ip, params, callback)
+}
+
+SimpleGeo.Places12.prototype.getNearbyPlaces = function (type,param,params,callback) {
     var param_string = "";
     var qs = "";
 

--- a/lib/simplegeo.js
+++ b/lib/simplegeo.js
@@ -104,20 +104,15 @@ SimpleGeo.Places = function(token, options) {
 	if (!(this instanceof SimpleGeo.Places)) return new SimpleGeo.Places(token, options);
 	SimpleGeo.call(this, token, options);
 	this.name = 'Places';
-	this.placesVersion = '/1.0';
+	this.placesVersion = '1.0';
 }
-
-SimpleGeo.Places.prototype = new SimpleGeo;
 
 SimpleGeo.Places12 = function(token, options) {
 	if (!(this instanceof SimpleGeo.Places12)) return new SimpleGeo.Places12(token, options);
 	SimpleGeo.call(this, token, options);
 	this.name = 'Places12';
-	this.placesVersion = '/1.2';
+	this.placesVersion = '1.2';
 }
-
-SimpleGeo.Places.prototype = new SimpleGeo;
-
 
 /////////////////////////////////////////////////////
 /** Storage                                       **/
@@ -225,6 +220,8 @@ SimpleGeo.LATLNG = 1;
 SimpleGeo.GEOHASH = 2;
 SimpleGeo.ADDRESS = 3;
 SimpleGeo.IP = 4;
+SimpleGeo.BBOX = 5;
+SimpleGeo.TEXT = 6;
 
 SimpleGeo.prototype.getNearbyRecordsByLatLng = function (layer,lat,lng,params,callback) {
     this.getNearbyRecords(layer,SimpleGeo.LATLNG,[lat,lng],params,callback);
@@ -377,7 +374,7 @@ SimpleGeo.prototype.getContext = function (type,param,callback) {
 /////////////////////////////////////////////////////
 
 /**
- * SimpleGeo Places: Search for Nearby Places
+ * SimpleGeo Places 1.0: Search for Nearby Places
  * @see https://simplegeo.com/docs/api-endpoints/simplegeo-places#search
  */
 SimpleGeo.Places.prototype = new SimpleGeo;
@@ -417,7 +414,7 @@ SimpleGeo.Places.prototype.getNearbyPlaces = function (type,param,params,callbac
     }
 
     qs = QueryString.stringify(params);
-    this.secure_call('1.0','/places/'+param_string+'.json?'+qs,'GET',callback);
+    this.secure_call(this.placesVersion,'/places/'+param_string+'.json?'+qs,'GET',callback);
 }
 
 /////////////////////////////////////////////////////
@@ -425,19 +422,17 @@ SimpleGeo.Places.prototype.getNearbyPlaces = function (type,param,params,callbac
 /////////////////////////////////////////////////////
 
 /**
- * SimpleGeo Places: Search for Nearby Places
+ * SimpleGeo Places 1.2: Search for Nearby Places
  * @see https://simplegeo.com/docs/api-endpoints/simplegeo-places#search
  */
-SimpleGeo.Places12.prototype.getNearbyPlacesByLatLng = function (lat, lng, params, callback) {
-  this.getNearbyPlaces(SimpleGeo.LATLNG, [lat,lng], params, callback)
+SimpleGeo.Places12.prototype = new SimpleGeo;
+
+SimpleGeo.Places12.prototype.getNearbyPlacesFromBBox = function (swLat, swLon, neLat, neLon, params, callback) {
+  this.getNearbyPlaces(SimpleGeo.BBOX, [swLat,swLon,neLat,neLon], params, callback)
 }
 
-SimpleGeo.Places12.prototype.getNearbyPlacesByAddress = function (address, params, callback) {
-  this.getNearbyPlaces(SimpleGeo.ADDRESS, address, params, callback)
-}
-
-SimpleGeo.Places12.prototype.getNearbyPlacesByIp = function (ip, params, callback) {
-  this.getNearbyPlaces(SimpleGeo.IP, ip, params, callback)
+SimpleGeo.Places12.prototype.getNearbyPlacesText = function (text, params, callback) {
+  this.getNearbyPlaces(SimpleGeo.TEXT, text, params, callback)
 }
 
 SimpleGeo.Places12.prototype.getNearbyPlaces = function (type,param,params,callback) {
@@ -450,18 +445,15 @@ SimpleGeo.Places12.prototype.getNearbyPlaces = function (type,param,params,callb
     }
 
     switch (type) {
-        case SimpleGeo.LATLNG :
-            param_string = param[0] + "," + param[1];
+        case SimpleGeo.BBOX :
+            param_string = param[0] + "," + param[1] + "," + param[2] + "," + param[3];
         break;
-        case SimpleGeo.ADDRESS : 
-            param_string = 'address';
-            params['address'] = param;
-        break;
-        case SimpleGeo.IP :
-            param_string = param;
+        case SimpleGeo.TEXT : 
+            param_string = 'search';
+            params['q'] = param;
         break;
     }
 
     qs = QueryString.stringify(params);
-    this.secure_call('1.0','/places/'+param_string+'.json?'+qs,'GET',callback);
+    this.secure_call(this.placesVersion,'/places/'+param_string+'.json?'+qs,'GET',callback);
 }


### PR DESCRIPTION
The latest master only included support for SimpleGeo Places 1.0. This commit includes support for Places 1.2. This was done by extending the SimpleGeo prototype to `SimpleGeo.Places` and `SimpleGeo.Places12`, respectively. The README has been updated to include information on how to use both versions of Places.

You must still use Places 1.0 if you intend to use `getNearbyPlacesByLatLng`, `getNearbyPlacesByAddress`, and `getNearbyPlacesByIp`. You should use Places 1.2 for `getNearbyPlacesFromBBox` and `getNearbyPlacesText`. The only overlap that exists is in the `getNearbyPlaces` function to stay as DRY as possible.

Please do send me a message/email with comments or suggestions. This is my first major commit to _any_ project, so thoughts would be much appreciated.
